### PR TITLE
Bug solved in JSON to MXML

### DIFF
--- a/quiz-generator/generate-quiz.py
+++ b/quiz-generator/generate-quiz.py
@@ -191,15 +191,14 @@ def json2mXML(jsonQuestion, quiz):
     tag = ElementTree.SubElement(tags, 'tag')
     tagText = ElementTree.SubElement(tag, 'text')
     tagText.text = 'Dificulty=' + str(jsonQuestion['difficulty'])
-    
+
     # adding other tags
     for jsonTag in jsonQuestion['tags']:
         if jsonTag['key']:
             tag = ElementTree.SubElement(tags, 'tag')
             tagText = ElementTree.SubElement(tag, 'text')
             tagText.text = jsonTag['key'] + ":" + ','.join(jsonTag['values'])
-    
-    
+
     # adding the answers in the file
     for jsonAnswer in jsonQuestion['answers']:
         answer = ElementTree.SubElement(question, 'answer')
@@ -232,12 +231,11 @@ if __name__ == '__main__':
 
     questions = submitQuery(question_collection, {})
 
-    quiz = questions
-    #quiz = generateQuiz(questions, quiz_settings)
+    quiz = generateQuiz(questions, quiz_settings)
 
     quizMXML = ElementTree.Element('quiz')
 
-    for question in questions:
+    for question in quiz:
         quizMXML = json2mXML(question, quizMXML)
 
     roughXML = ElementTree.tostring(quizMXML)


### PR DESCRIPTION
Initially, the tags were added directly from "tags" in JSON. Now the tags are stored in a map so I added the tags in the form of
   'key':'values-list'
The values in the list are separated by commas.