### PR TITLE
[convert] Add category option for MXML converter

### DIFF
--- a/src/parsers/mxml.py
+++ b/src/parsers/mxml.py
@@ -35,13 +35,23 @@ def set_meta(question_dict: dict, key: str, value: any):
         question_dict["metadata"][key].append(value)
 
 
-def quiz_json_to_mxml(json_arr: list):
+def quiz_json_to_mxml(json_arr: list, category: str = None) -> ElementTree.Element:
     """
     Converts a JSON quiz to MXML quiz
     :param file_content: a quiz stored in JSON format
     :return: a quiz stored in MXML format
     """
     quiz_mxml = ElementTree.Element("quiz")
+
+    # Add optional category to MXML quiz
+    if (category is not None):
+        question = ElementTree.SubElement(ElementTree.Element("quiz"), "question")
+        question.set("type", "category")
+        category_text = ElementTree.SubElement(ElementTree.SubElement(question, "category"), "text")
+        category_text.text = category
+
+        quiz_mxml.append(question)
+
     for mxml_elem in list(map(json_to_mxml, json_arr)):
         quiz_mxml.append(mxml_elem)
 

--- a/src/quiz_manager.py
+++ b/src/quiz_manager.py
@@ -35,7 +35,13 @@ def cli():
     type=click.Choice(["JSON", "HR", "MXML"], case_sensitive=False),
     help="The output format",
 )
-def convert(input_file_path, output_file_path, input_format, output_format):
+@click.option(
+    "-c",
+    "--category",
+    required=False,
+    help="Category specifier for MXML quizzes",
+)
+def convert(input_file_path, output_file_path, input_format, output_format, category=None):
     """
     Converts files to different formats.
     """
@@ -68,12 +74,12 @@ def convert(input_file_path, output_file_path, input_format, output_format):
         if output_format == "HR":
             conversion = hr.quiz_json_to_hr(input_content)
         elif output_format == "MXML":
-            conversion = mxml.quiz_json_to_mxml(input_content)
+            conversion = mxml.quiz_json_to_mxml(input_content, category)
     elif input_format == "HR":
         if output_format == "JSON":
             conversion = hr.quiz_hr_to_json(input_content)
         elif output_format == "MXML":
-            conversion = mxml.quiz_json_to_mxml(hr.quiz_hr_to_json(input_content))
+            conversion = mxml.quiz_json_to_mxml(hr.quiz_hr_to_json(input_content), category)
     elif input_format == "MXML":
         if output_format == "JSON":
             conversion = mxml.quiz_mxml_to_json(input_content)


### PR DESCRIPTION
Add a new `-c` / `--category` option for the convert subcommand that adds
a new question with type `category` at the beginning of the MXML quiz.
```
<question type="category">
	<category>
		<text>Lucrare1</text>
	</category>
</question>
<question type="multichoice">
	<name>
		<text>Test Question Statement?</text>
	</name>
	[...]
```
Closes #55 

Signed-off-by: Costin-Robert Sin <sin.costinrobert@gmail.com>