### PR TITLE
checkers: Fix ratio check for `specific` option

### DIFF
--- a/src/checkers/check_hr.py
+++ b/src/checkers/check_hr.py
@@ -132,20 +132,15 @@ def check_specific(filename: str, file: int, config_filename: str) -> int:
         line_idx += 1
         line = file.readline()
 
-    answers_number_ok = False
-    answers_ratio_ok = False
-    for total_answers in answers_options.items():
-        if (correct_answers + wrong_answers) == total_answers:
-            answers_number_ok = True
-            if correct_answers == answers_options[total_answers]:
-                answers_ratio_ok = True
-            break
-
-    if not answers_number_ok:
-        print_error(filename, line_idx, ": Wrong answers number at the question above!\n")
-    elif not answers_ratio_ok:
+    supposed_correct_answers = answers_options.get(correct_answers + wrong_answers)
+    if supposed_correct_answers == None:
         print_error(filename, line_idx,
-                ": Wrong correct / wrong answers ratio at the question above!\n")
+                    ": The question does not have the right number of answers! (should be one of { " +
+                    ", ".join([str(x) for x in (answers_options.keys())]) +
+                    "})\n")
+    elif supposed_correct_answers != correct_answers:
+        print_error(filename, line_idx,
+                    ": The question has bad correct / wrong answers ratio!\n")
 
     return return_value
 


### PR DESCRIPTION
The way `total_answers` is defined in `check_specific()` comes up as a pair of values: (totalAnswersNumber, correctAnswersNumber). Printing `total_answers` results in something like this:

```patch
diff --git a/src/checkers/check_hr.py b/src/checkers/check_hr.py
index 2baa51c..b816957 100644
--- a/src/checkers/check_hr.py
+++ b/src/checkers/check_hr.py
@@ -135,6 +135,7 @@ def check_specific(filename: str, file: int, config_filename: str) -> int:
     answers_number_ok = False
     answers_ratio_ok = False
     for total_answers in answers_options.items():
+        print(total_answers)
         if (correct_answers + wrong_answers) == total_answers[0]:
             answers_number_ok = True
             if correct_answers == total_answers[1]:
```

```console
(4, 1)
(5, 2)
(7, 3)
```

This PR updates the check of the ratio using the info above.

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>